### PR TITLE
changes to @rel for issue #17

### DIFF
--- a/includes/error-sample.js
+++ b/includes/error-sample.js
@@ -4,27 +4,27 @@
   "version" : "1.0",
   "error" : 
   {
-   "rel" : ["https://tools.ietf.org/html/http-problem-00"],
+   "rel" : ["https://example.com/rels/http-problem"],
    "data" : 
    [
     {
      "name" : "type", 
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#type"],
+     "rel" : ["https://example.com/rels/http-problem#type"],
      "value" : "out-of-credit"
     },
     {
      "name" : "title", 
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#title"],
+     "rel" : ["https://example.com/rels/http-problem#title"],
      "value" : "You do not have enough credit"
     },
     {
      "name" : "detail", 
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#detail"],
+     "rel" : ["https://example.com/rels/http-problem#detail"],
      "value" : "Your balance is 30, but the cost is 50."
     },
     {
      "name" : "balance", 
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#balance"],
+     "rel" : ["https://example.com/rels/http-problem#balance"],
      "value" : "30"
     }
    ]

--- a/includes/error-sample.js
+++ b/includes/error-sample.js
@@ -4,7 +4,6 @@
   "version" : "1.0",
   "error" : 
   {
-   "rel" : ["https://example.com/rels/http-problem"],
    "data" : 
    [
     {

--- a/includes/error-sample.js
+++ b/includes/error-sample.js
@@ -1,15 +1,34 @@
 {
-  "uber" :
+ "uber" :
+ {
+  "version" : "1.0",
+  "error" : 
   {
-    "version" : "1.0",
-    "error" : 
+   "rel" : "[https://tools.ietf.org/html/http-problem-00]",
+   "data" : 
+   [
     {
-      "data" : 
-      [
-        {"name" : "code", "value" : "q1w2e3"},
-        {"name" : "dump", "url" : "http://example.org/debug/1"}
-      ]
+     "name" : "type", 
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#type]",
+     "value" : "out-of-credit"
+    },
+    {
+     "name" : "title", 
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#title]",
+     "value" : "You do not have enough credit"
+    },
+    {
+     "name" : "detail", 
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#detail]",
+     "value" : "Your balance is 30, but the cost is 50."
+    },
+    {
+     "name" : "balance", 
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#balance]",
+     "value" : "30"
     }
+   ]
   }
+ }
 }
 

--- a/includes/error-sample.js
+++ b/includes/error-sample.js
@@ -4,27 +4,27 @@
   "version" : "1.0",
   "error" : 
   {
-   "rel" : "[https://tools.ietf.org/html/http-problem-00]",
+   "rel" : ["https://tools.ietf.org/html/http-problem-00"],
    "data" : 
    [
     {
      "name" : "type", 
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#type]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#type"],
      "value" : "out-of-credit"
     },
     {
      "name" : "title", 
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#title]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#title"],
      "value" : "You do not have enough credit"
     },
     {
      "name" : "detail", 
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#detail]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#detail"],
      "value" : "Your balance is 30, but the cost is 50."
     },
     {
      "name" : "balance", 
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#balance]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#balance"],
      "value" : "30"
     }
    ]

--- a/includes/error-sample.xml
+++ b/includes/error-sample.xml
@@ -1,5 +1,5 @@
 <uber version="1.0">
-  <error rel="https://example.com/rels/http-problem">
+  <error>
     <data name="type" 
       rel="https://example.com/rels/http-problem#type">
       out-of-credit

--- a/includes/error-sample.xml
+++ b/includes/error-sample.xml
@@ -1,7 +1,20 @@
 <uber version="1.0">
-  <error>
-    <data name="code">q1w2e3</data>
-    <data name="dump" url="http://example.org/debug/1" />
+  <error rel="https://tools.ietf.org/html/http-problem-00">
+    <data name="type" 
+      rel="https://tools.ietf.org/html/http-problem-00#type">
+      out-of-credit
+    </data>
+    <data name="title"
+      rel="https://tools.ietf.org/html/http-problem-00#title">
+      You do not have enough credit
+    </data>
+    <data name="detail"
+      rel="https://tools.ietf.org/html/http-problem-00#detail">
+      Your current balance is 30, but the cost is 50
+    </data>
+    <data name="balance"
+      rel="https://tools.ietf.org/html/http-problem-00#balance">
+    </data>  
   </error>
 </uber>
 

--- a/includes/error-sample.xml
+++ b/includes/error-sample.xml
@@ -1,19 +1,19 @@
 <uber version="1.0">
-  <error rel="https://tools.ietf.org/html/http-problem-00">
+  <error rel="https://example.com/rels/http-problem">
     <data name="type" 
-      rel="https://tools.ietf.org/html/http-problem-00#type">
+      rel="https://example.com/rels/http-problem#type">
       out-of-credit
     </data>
     <data name="title"
-      rel="https://tools.ietf.org/html/http-problem-00#title">
+      rel="https://example.com/rels/http-problem#title">
       You do not have enough credit
     </data>
     <data name="detail"
-      rel="https://tools.ietf.org/html/http-problem-00#detail">
+      rel="https://example.com/rels/http-problem#detail">
       Your current balance is 30, but the cost is 50
     </data>
     <data name="balance"
-      rel="https://tools.ietf.org/html/http-problem-00#balance">
+      rel="https://example.com/rels/http-problem#balance">
     </data>  
   </error>
 </uber>

--- a/uber-hypermedia.asciidoc
+++ b/uber-hypermedia.asciidoc
@@ -144,6 +144,8 @@ The +<data>+ element is the key element in the model. A valid UBER message SHOUL
 
 +rel+::
   Contains a list of link relation values. These values SHOULD conform to the guidance provided in RFC5988 <<rfc5988, [RFC5988]>>. In the XML variant the list of link relation values appears as a space-separated list. In the JSON variant the list of link realtion values appears as an array.
++
+In UBER documents, the +rel+ property is used to supply domain-related semantic information for the associated +data+ element. This applies equally to +data+ elements used as hypermedia links (e.g. those with a valid +url+ property) and +data+ elements used to carry simple values (e.g. strings and numbers). 
 
 +url+::
   A resolvable URL associated with this element. The value SHOULD conform to that described in RFC3986 <<rfc3986,[RFC3986]>>.

--- a/uber-hypermedia.html
+++ b/uber-hypermedia.html
@@ -628,27 +628,27 @@ string
   "version" : "1.0",
   "error" :
   {
-   "rel" : "[https://tools.ietf.org/html/http-problem-00]",
+   "rel" : ["https://tools.ietf.org/html/http-problem-00"],
    "data" :
    [
     {
      "name" : "type",
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#type]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#type"],
      "value" : "out-of-credit"
     },
     {
      "name" : "title",
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#title]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#title"],
      "value" : "You do not have enough credit"
     },
     {
      "name" : "detail",
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#detail]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#detail"],
      "value" : "Your balance is 30, but the cost is 50."
     },
     {
      "name" : "balance",
-     "rel" : "[https://tools.ietf.org/html/http-problem-00#balance]",
+     "rel" : ["https://tools.ietf.org/html/http-problem-00#balance"],
      "value" : "30"
     }
    ]

--- a/uber-hypermedia.html
+++ b/uber-hypermedia.html
@@ -600,7 +600,7 @@ string
 <div class="title">Example <span class="monospaced">&lt;error&gt;</span> Element (XML)</div>
 <div class="content monospaced">
 <pre>&lt;uber version="1.0"&gt;
-  &lt;error rel="https://example.com/rels/http-problem"&gt;
+  &lt;error&gt;
     &lt;data name="type"
       rel="https://example.com/rels/http-problem#type"&gt;
       out-of-credit
@@ -628,7 +628,6 @@ string
   "version" : "1.0",
   "error" :
   {
-   "rel" : ["https://example.com/rels/http-problem"],
    "data" :
    [
     {

--- a/uber-hypermedia.html
+++ b/uber-hypermedia.html
@@ -409,6 +409,7 @@ Dublin Core Metadata Element Set, Version 1.1 <a href="#dc-rel">[DC-REL]</a>
 <p>
   Contains a list of link relation values. These values SHOULD conform to the guidance provided in RFC5988 <a href="#rfc5988">[RFC5988]</a>. In the XML variant the list of link relation values appears as a space-separated list. In the JSON variant the list of link realtion values appears as an array.
 </p>
+<div class="paragraph"><p>In UBER documents, the <span class="monospaced">rel</span> property is used to supply domain-related semantic information for the associated <span class="monospaced">data</span> element. This applies equally to <span class="monospaced">data</span> elements used as hypermedia links (e.g. those with a valid <span class="monospaced">url</span> property) and <span class="monospaced">data</span> elements used to carry simple values (e.g. strings and numbers).</p></div>
 </dd>
 <dt class="hdlist1">
 <span class="monospaced">url</span>
@@ -599,9 +600,22 @@ string
 <div class="title">Example <span class="monospaced">&lt;error&gt;</span> Element (XML)</div>
 <div class="content monospaced">
 <pre>&lt;uber version="1.0"&gt;
-  &lt;error&gt;
-    &lt;data name="code"&gt;q1w2e3&lt;/data&gt;
-    &lt;data name="dump" url="http://example.org/debug/1" /&gt;
+  &lt;error rel="https://tools.ietf.org/html/http-problem-00"&gt;
+    &lt;data name="type"
+      rel="https://tools.ietf.org/html/http-problem-00#type"&gt;
+      out-of-credit
+    &lt;/data&gt;
+    &lt;data name="title"
+      rel="https://tools.ietf.org/html/http-problem-00#title"&gt;
+      You do not have enough credit
+    &lt;/data&gt;
+    &lt;data name="detail"
+      rel="https://tools.ietf.org/html/http-problem-00#detail"&gt;
+      Your current balance is 30, but the cost is 50
+    &lt;/data&gt;
+    &lt;data name="balance"
+      rel="https://tools.ietf.org/html/http-problem-00#balance"&gt;
+    &lt;/data&gt;
   &lt;/error&gt;
 &lt;/uber&gt;</pre>
 </div></div>
@@ -609,18 +623,37 @@ string
 <div class="title">Example <span class="monospaced">&lt;error&gt;</span> Element (JSON)</div>
 <div class="content monospaced">
 <pre>{
-  "uber" :
+ "uber" :
+ {
+  "version" : "1.0",
+  "error" :
   {
-    "version" : "1.0",
-    "error" :
+   "rel" : "[https://tools.ietf.org/html/http-problem-00]",
+   "data" :
+   [
     {
-      "data" :
-      [
-        {"name" : "code", "value" : "q1w2e3"},
-        {"name" : "dump", "url" : "http://example.org/debug/1"}
-      ]
+     "name" : "type",
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#type]",
+     "value" : "out-of-credit"
+    },
+    {
+     "name" : "title",
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#title]",
+     "value" : "You do not have enough credit"
+    },
+    {
+     "name" : "detail",
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#detail]",
+     "value" : "Your balance is 30, but the cost is 50."
+    },
+    {
+     "name" : "balance",
+     "rel" : "[https://tools.ietf.org/html/http-problem-00#balance]",
+     "value" : "30"
     }
+   ]
   }
+ }
 }</pre>
 </div></div>
 </div>
@@ -1146,7 +1179,7 @@ Irakli Nadareishvili.</p></div>
 <div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-04-04 08:45:12 EDT
+Last updated 2015-04-04 16:52:12 EDT
 </div>
 </div>
 </body>

--- a/uber-hypermedia.html
+++ b/uber-hypermedia.html
@@ -600,21 +600,21 @@ string
 <div class="title">Example <span class="monospaced">&lt;error&gt;</span> Element (XML)</div>
 <div class="content monospaced">
 <pre>&lt;uber version="1.0"&gt;
-  &lt;error rel="https://tools.ietf.org/html/http-problem-00"&gt;
+  &lt;error rel="https://example.com/rels/http-problem"&gt;
     &lt;data name="type"
-      rel="https://tools.ietf.org/html/http-problem-00#type"&gt;
+      rel="https://example.com/rels/http-problem#type"&gt;
       out-of-credit
     &lt;/data&gt;
     &lt;data name="title"
-      rel="https://tools.ietf.org/html/http-problem-00#title"&gt;
+      rel="https://example.com/rels/http-problem#title"&gt;
       You do not have enough credit
     &lt;/data&gt;
     &lt;data name="detail"
-      rel="https://tools.ietf.org/html/http-problem-00#detail"&gt;
+      rel="https://example.com/rels/http-problem#detail"&gt;
       Your current balance is 30, but the cost is 50
     &lt;/data&gt;
     &lt;data name="balance"
-      rel="https://tools.ietf.org/html/http-problem-00#balance"&gt;
+      rel="https://example.com/rels/http-problem#balance"&gt;
     &lt;/data&gt;
   &lt;/error&gt;
 &lt;/uber&gt;</pre>
@@ -628,27 +628,27 @@ string
   "version" : "1.0",
   "error" :
   {
-   "rel" : ["https://tools.ietf.org/html/http-problem-00"],
+   "rel" : ["https://example.com/rels/http-problem"],
    "data" :
    [
     {
      "name" : "type",
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#type"],
+     "rel" : ["https://example.com/rels/http-problem#type"],
      "value" : "out-of-credit"
     },
     {
      "name" : "title",
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#title"],
+     "rel" : ["https://example.com/rels/http-problem#title"],
      "value" : "You do not have enough credit"
     },
     {
      "name" : "detail",
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#detail"],
+     "rel" : ["https://example.com/rels/http-problem#detail"],
      "value" : "Your balance is 30, but the cost is 50."
     },
     {
      "name" : "balance",
-     "rel" : ["https://tools.ietf.org/html/http-problem-00#balance"],
+     "rel" : ["https://example.com/rels/http-problem#balance"],
      "value" : "30"
     }
    ]


### PR DESCRIPTION
update prose to clarify use of `rel` for both hypermedia and value elements. updated `<error>` example to illustrate.