### PR TITLE
Update xml error-sample to match json-sample

### DIFF
--- a/includes/error-sample.xml
+++ b/includes/error-sample.xml
@@ -14,6 +14,7 @@
     </data>
     <data name="balance"
       rel="https://example.com/rels/http-problem#balance">
+      30
     </data>  
   </error>
 </uber>


### PR DESCRIPTION
The XML error-sample misses the `balance` value that is present in the JSON sample.